### PR TITLE
Web app password generator length slider does not work correctly for some languages

### DIFF
--- a/apps/server/AliasVault.Client/Main/Components/Settings/PasswordSettingsPopup.razor
+++ b/apps/server/AliasVault.Client/Main/Components/Settings/PasswordSettingsPopup.razor
@@ -1,5 +1,6 @@
 @using AliasVault.Client.Main.Components.Layout
 @using AliasVault.Client.Main.Utilities
+@using System.Globalization
 @inject DbService DbService
 @inject GlobalLoadingService GlobalLoadingService
 @inject GlobalNotificationService GlobalNotificationService
@@ -15,9 +16,9 @@
                 <div class="mt-4 space-y-4">
                     <div>
                         <label for="password-length" class="block text-sm font-medium text-gray-700 dark:text-gray-300">@string.Format(Localizer["PasswordLengthLabel"], _workingSettings.Length)</label>
-                        <input type="range" id="password-length" min="@PasswordLengthSlider.SliderMin" max="@PasswordLengthSlider.SliderMax" step="0.1"
+                        <input type="range" id="password-length" min="@PasswordLengthSlider.SliderMin.ToString(CultureInfo.InvariantCulture)" max="@PasswordLengthSlider.SliderMax.ToString(CultureInfo.InvariantCulture)" step="0.1"
                             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                            value="@_sliderValue" @oninput="HandleLengthInput">
+                            value="@_sliderValue.ToString(CultureInfo.InvariantCulture)" @oninput="HandleLengthInput">
                     </div>
 
                     <div class="flex items-center">
@@ -165,7 +166,7 @@
     /// </summary>
     private async Task HandleLengthInput(ChangeEventArgs e)
     {
-        if (double.TryParse(e.Value?.ToString(), out var sliderValue))
+        if (double.TryParse(e.Value?.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var sliderValue))
         {
             _sliderValue = sliderValue;
             _workingSettings.Length = PasswordLengthSlider.SliderToLength(sliderValue);


### PR DESCRIPTION
## Description
Issue was caused by certain locales like German that have different thousands separators compared to english, causing issues during int conversions.

- [x] Bug fix

## Related Issues
- #2002

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.

