### PR TITLE
Fix Android passkeys not working in the PayPal app and others

### DIFF
--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/credentialprovider/OriginVerifier.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/credentialprovider/OriginVerifier.kt
@@ -1059,7 +1059,7 @@ class OriginVerifier {
 
     /**
      * Verify that a native app is authorized for the given RP ID via Asset Links.
-     * Fetches /.well-known/assetlinks.json and checks for get_login_creds permission.
+     * Fetches /.well-known/assetlinks.json and checks for get_login_creds or handle_all_urls permission.
      */
     private fun verifyAssetLinks(rpId: String, packageName: String, certHashes: List<String>): AssetLinksResult {
         return try {
@@ -1117,10 +1117,11 @@ class OriginVerifier {
         if (target.optString("namespace") != "android_app") return false
         if (target.optString("package_name") != packageName) return false
 
-        val hasGetLoginCreds = (0 until relation.length()).any { j ->
-            relation.getString(j) == "delegate_permission/common.get_login_creds"
+        val hasCredentialRelation = (0 until relation.length()).any { j ->
+            val rel = relation.getString(j)
+            rel == "delegate_permission/common.get_login_creds" || rel == "delegate_permission/common.handle_all_urls"
         }
-        if (!hasGetLoginCreds) return false
+        if (!hasCredentialRelation) return false
 
         val fingerprints = target.optJSONArray("sha256_cert_fingerprints") ?: return false
         return (0 until fingerprints.length()).any { j ->


### PR DESCRIPTION
## Description
- [x] Bug fix

**Relax Digital Asset Links relation validation for passkeys on Android:**

For Android apps that want to create/read passkeys from AliasVault, AliasVault does a check where it fetches the `https://[rpId]/.well-known/assetlinks.json` file and checks for the `get_login_creds` permission.

Previously we only accepted:

- `delegate_permission/common.get_login_creds`

Now we accept either:

- `delegate_permission/common.get_login_creds`
- `delegate_permission/common.handle_all_urls`

We intentionally relax this validation to improve compatibility with real-world Android passkey deployments. In practice, many major services only publish `handle_all_urls`, as an example, this is the PayPal.com assetlinks.json at the time of writing (20260531):
```

[{
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target" : {
      "namespace": "android_app",
      "package_name": "com.paypal.android.p2pmobile",
      "sha256_cert_fingerprints": ["B4:53:D3:7C:78:28:56:F7:82:A8:E0:9F:14:EE:20:B8:4F:49:A3:10:75:F4:7F:D3:A0:79:82:D8:CA:FE:FF:D9",
                                   "C7:C6:2E:A0:F6:E2:F6:EB:A8:7F:95:40:69:87:50:55:30:EF:2F:51:6E:7C:DE:59:91:D7:14:03:31:44:80:72",
                                   "DB:EE:80:B6:07:32:0F:B8:24:C6:E6:FA:BE:D6:97:A7:7E:18:D9:60:1A:48:43:31:40:EF:22:AD:6A:71:48:9F",
                                   "69:25:88:A7:D1:8B:D1:55:DA:4E:6E:25:36:28:0F:2C:BE:4B:42:DF:7C:86:C6:42:46:1A:6C:0B:DF:3B:AB:28"]
      }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target" : {
      "namespace": "android_app",
      "package_name": "com.paypal.android.p2pmobile.debug",
      "sha256_cert_fingerprints": ["B4:53:D3:7C:78:28:56:F7:82:A8:E0:9F:14:EE:20:B8:4F:49:A3:10:75:F4:7F:D3:A0:79:82:D8:CA:FE:FF:D9"]
      }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "com.venmo.fifa",
      "sha256_cert_fingerprints": [
        "8E:5E:61:2A:64:3F:E9:63:8B:C3:FA:9E:B2:49:8E:43:97:C9:ED:46:31:23:B1:89:CB:CF:E3:37:5E:34:B0:4A"
      ]
    }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "com.venmo",
      "sha256_cert_fingerprints": [
        "C7:7E:26:31:AC:04:51:C0:86:F2:5F:79:AE:25:82:38:AF:A4:00:96:1E:8D:59:9D:B7:8E:25:EA:DC:DC:C9:47"
      ]
    }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target" : {
      "namespace": "android_app",
      "package_name": "com.paypal.android.p2pmobile.pp_beta",
      "sha256_cert_fingerprints": [
        "B5:32:9B:42:22:50:FA:81:98:07:21:6C:8A:C9:08:B8:79:3A:D4:82:90:18:B9:80:1E:C7:54:E2:0D:C0:40:B2",
        "B4:53:D3:7C:78:28:56:F7:82:A8:E0:9F:14:EE:20:B8:4F:49:A3:10:75:F4:7F:D3:A0:79:82:D8:CA:FE:FF:D9"
      ]
    }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "com.izettle.android.debug",
      "sha256_cert_fingerprints": ["1F:6C:B1:82:40:93:0F:06:92:92:F6:50:EA:5E:51:32:A7:F9:6B:F5:93:EF:B9:A9:CA:CC:B8:DD:09:B2:BD:09"]
    }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "com.zettle.android.sdk.example.integration",
      "sha256_cert_fingerprints": ["1F:6C:B1:82:40:93:0F:06:92:92:F6:50:EA:5E:51:32:A7:F9:6B:F5:93:EF:B9:A9:CA:CC:B8:DD:09:B2:BD:09"]
    }
  },
  {
    "relation": ["delegate_permission/common.handle_all_urls"],
    "target": {
      "namespace": "android_app",
      "package_name": "com.izettle.android",
      "sha256_cert_fingerprints": [
        "F2:0B:61:10:5A:66:C5:0D:BA:50:82:C7:4E:D0:62:26:65:F2:F4:3A:6C:2A:3E:B2:3D:25:D4:32:8B:B9:49:B5",
        "D1:31:C9:E2:2C:B9:88:80:5F:6E:4E:1B:5B:2A:9D:DC:7F:E7:F5:D8:02:2D:45:21:9D:49:3D:03:2B:A4:ED:9E"
      ]
    }
  }
]
```

We therefore have decided to accept both relations `common.get_login_creds` OR `common.handle_all_urls` because it adds effectively zero attack surface in practice:
- the website must still publish a valid `assetlinks.json`
- the Android package name must still match
- the signing certificate fingerprint must still match

The signing certificate + package verification remains the actual security boundary; the relation string itself is effectively a capability label.

If all the major Android apps (and the Android ecosystem in general) start consistently using a properly documented standard, we can revisit and tighten this validation again in the future.

## Related Issues
- #2111

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.

