### PR TITLE
Security autofill tightening

### DIFF
--- a/apps/browser-extension/src/entrypoints/contentScript/AutofillFrameUrl.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/AutofillFrameUrl.ts
@@ -1,0 +1,16 @@
+export type AutofillFrameLocation = Pick<Location, 'protocol' | 'hostname' | 'href'>;
+
+/**
+ * Return the current frame URL only when it represents a real web origin.
+ * AliasVault must not title-match credentials inside about/srcdoc/blob frames.
+ */
+export function getCurrentAutofillFrameUrl(currentLocation: AutofillFrameLocation = window.location): string | null {
+  if (
+    (currentLocation.protocol !== 'https:' && currentLocation.protocol !== 'http:') ||
+    !currentLocation.hostname
+  ) {
+    return null;
+  }
+
+  return currentLocation.href;
+}

--- a/apps/browser-extension/src/entrypoints/contentScript/Popup.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/Popup.ts
@@ -17,6 +17,8 @@ import { SqliteClient } from '@/utils/SqliteClient';
 
 import { t } from '@/i18n/StandaloneI18n';
 
+import { getCurrentAutofillFrameUrl } from './AutofillFrameUrl';
+
 /**
  * WeakMap to store event listeners for popup containers
  */
@@ -126,11 +128,18 @@ export function openAutofillPopup(input: HTMLInputElement, container: HTMLElemen
   document.addEventListener('keydown', handleEnterKey);
 
   (async () : Promise<void> => {
+    const currentUrl = getCurrentAutofillFrameUrl();
+    if (!currentUrl) {
+      removeExistingPopup(container);
+      document.removeEventListener('keydown', handleEnterKey);
+      return;
+    }
+
     // Load autofill matching mode setting to send to background for filtering
     const matchingMode = await LocalPreferencesService.getAutofillMatchingMode();
 
     const response = await sendMessage('GET_FILTERED_ITEMS', {
-      currentUrl: window.location.href,
+      currentUrl,
       pageTitle: document.title,
       matchingMode: matchingMode,
       includeRecentlySelected: true // Enable for multi-step login autofill
@@ -177,10 +186,17 @@ export function openTotpPopup(input: HTMLInputElement, container: HTMLElement, f
   document.addEventListener('keydown', handleEnterKey);
 
   (async () : Promise<void> => {
+    const currentUrl = getCurrentAutofillFrameUrl();
+    if (!currentUrl) {
+      removeExistingPopup(container);
+      document.removeEventListener('keydown', handleEnterKey);
+      return;
+    }
+
     const matchingMode = await LocalPreferencesService.getAutofillMatchingMode();
 
     const response = await sendMessage('GET_ITEMS_WITH_TOTP', {
-      currentUrl: window.location.href,
+      currentUrl,
       pageTitle: document.title,
       matchingMode: matchingMode
     });

--- a/apps/browser-extension/src/entrypoints/contentScript/Popup.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/Popup.ts
@@ -106,6 +106,22 @@ const createSuggestedNameSpan = (name: string): HTMLElement => {
 };
 
 /**
+ * Check if an outside-click event originated from AliasVault UI controls.
+ * Shadow DOM events retarget to the host, so use the composed path instead of
+ * only checking event.target.
+ */
+function isClickInsidePopupUi(event: MouseEvent, popup: Element, input: HTMLInputElement): boolean {
+  const eventPath = event.composedPath();
+
+  return eventPath.includes(popup) ||
+    eventPath.includes(input) ||
+    eventPath.some((pathTarget) => (
+      pathTarget instanceof Element &&
+      pathTarget.closest('.av-input-icon') !== null
+    ));
+}
+
+/**
  * Open (or refresh) the autofill popup including check if vault is locked.
  * @param input - The input element that triggered the popup
  * @param container - The container element
@@ -380,19 +396,14 @@ async function createTotpPopup(input: HTMLInputElement, items: Item[] | undefine
    */
   const handleClickOutside = (event: MouseEvent) : void => {
     const popupElement = rootContainer.querySelector('#aliasvault-credential-popup');
-    const target = event.target as Node;
-    const targetElement = event.target as HTMLElement;
     // If popup doesn't exist, remove the listener
     if (!popupElement) {
       document.removeEventListener('mousedown', handleClickOutside);
       return;
     }
 
-    // Check if the click is on the AliasVault icon
-    const isIconClick = targetElement.closest('.av-input-icon') !== null;
-
-    // Check if the click is outside the popup and outside the shadow UI
-    if (popupElement && !popupElement.contains(target) && !input.contains(target) && !isIconClick && targetElement.tagName !== 'ALIASVAULT-UI') {
+    // Check if the click is outside the popup and outside the input/icon UI.
+    if (!isClickInsidePopupUi(event, popupElement, input)) {
       removeExistingPopup(rootContainer);
     }
   };
@@ -1112,19 +1123,14 @@ export async function createAutofillPopup(input: HTMLInputElement, items: Item[]
    */
   const handleClickOutside = (event: MouseEvent) : void => {
     const popup = rootContainer.querySelector('#aliasvault-credential-popup');
-    const target = event.target as Node;
-    const targetElement = event.target as HTMLElement;
     // If popup doesn't exist, remove the listener
     if (!popup) {
       document.removeEventListener('mousedown', handleClickOutside);
       return;
     }
 
-    // Check if the click is on the AliasVault icon
-    const isIconClick = targetElement.closest('.av-input-icon') !== null;
-
-    // Check if the click is outside the popup and outside the shadow UI
-    if (popup && !popup.contains(target) && !input.contains(target) && !isIconClick && targetElement.tagName !== 'ALIASVAULT-UI') {
+    // Check if the click is outside the popup and outside the input/icon UI.
+    if (!isClickInsidePopupUi(event, popup, input)) {
       removeExistingPopup(rootContainer);
     }
   };
@@ -1208,14 +1214,8 @@ export async function createVaultLockedPopup(input: HTMLInputElement, rootContai
    * Add event listener to document to close popup when clicking outside.
    */
   const handleClickOutside = (event: MouseEvent): void => {
-    const target = event.target as Node;
-    const targetElement = event.target as HTMLElement;
-
-    // Check if the click is on the AliasVault icon
-    const isIconClick = targetElement.closest('.av-input-icon') !== null;
-
-    // Check if the click is outside the popup and outside the shadow UI
-    if (popup && !popup.contains(target) && !input.contains(target) && !isIconClick && targetElement.tagName !== 'ALIASVAULT-UI') {
+    // Check if the click is outside the popup and outside the input/icon UI.
+    if (!isClickInsidePopupUi(event, popup, input)) {
       removeExistingPopup(rootContainer);
       document.removeEventListener('mousedown', handleClickOutside);
     }
@@ -2635,14 +2635,8 @@ export async function createUpgradeRequiredPopup(input: HTMLInputElement, rootCo
    * Add event listener to document to close popup when clicking outside.
    */
   const handleClickOutside = (event: MouseEvent): void => {
-    const target = event.target as Node;
-    const targetElement = event.target as HTMLElement;
-
-    // Check if the click is on the AliasVault icon
-    const isIconClick = targetElement.closest('.av-input-icon') !== null;
-
-    // Check if the click is outside the popup and outside the shadow UI
-    if (popup && !popup.contains(target) && !input.contains(target) && !isIconClick && targetElement.tagName !== 'ALIASVAULT-UI') {
+    // Check if the click is outside the popup and outside the input/icon UI.
+    if (!isClickInsidePopupUi(event, popup, input)) {
       removeExistingPopup(rootContainer);
       document.removeEventListener('mousedown', handleClickOutside);
     }

--- a/apps/browser-extension/src/entrypoints/contentScript/WebAuthnInterceptor.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/WebAuthnInterceptor.ts
@@ -58,6 +58,29 @@ function isPageReadyForWebAuthn(): boolean {
 }
 
 /**
+ * Check whether a frame has the same origin as every ancestor frame.
+ * Cross-origin iframe WebAuthn requires browser-level Permissions Policy checks,
+ * so AliasVault must fall back to native WebAuthn when any ancestor differs.
+ */
+export function isSameOriginWithAncestors(currentWindow: Window = window): boolean {
+  let frame: Window = currentWindow;
+  const expectedOrigin = currentWindow.location.origin;
+
+  while (frame !== frame.parent) {
+    try {
+      if (frame.parent.location.origin !== expectedOrigin) {
+        return false;
+      }
+      frame = frame.parent;
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Initialize the WebAuthn interceptor
  */
 export async function initializeWebAuthnInterceptor(_ctx: any): Promise<void> {
@@ -99,6 +122,14 @@ export async function initializeWebAuthnInterceptor(_ctx: any): Promise<void> {
     };
 
     try {
+      if (!isSameOriginWithAncestors()) {
+        dispatchResponse({
+          requestId,
+          fallback: true
+        });
+        return;
+      }
+
       if (!validateWebAuthnEventDetail('create', detail, window.location.origin, window.location.hostname)) {
         dispatchResponse({
           requestId,
@@ -191,6 +222,14 @@ export async function initializeWebAuthnInterceptor(_ctx: any): Promise<void> {
     };
 
     try {
+      if (!isSameOriginWithAncestors()) {
+        dispatchResponse({
+          requestId,
+          fallback: true
+        });
+        return;
+      }
+
       if (!validateWebAuthnEventDetail('get', detail, window.location.origin, window.location.hostname)) {
         dispatchResponse({
           requestId,

--- a/apps/browser-extension/src/entrypoints/contentScript/__tests__/AutofillFrameUrl.test.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/__tests__/AutofillFrameUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type AutofillFrameLocation,
+  getCurrentAutofillFrameUrl
+} from '../AutofillFrameUrl';
+
+/**
+ * Build the minimal Location shape used by the autofill frame URL guard.
+ */
+const frameLocation = (protocol: string, hostname: string, href: string): AutofillFrameLocation => ({
+  protocol,
+  hostname,
+  href,
+});
+
+describe('AutofillFrameUrl', () => {
+  it('allows http and https frame URLs with a hostname', () => {
+    expect(getCurrentAutofillFrameUrl(frameLocation(
+      'https:',
+      'login.example.com',
+      'https://login.example.com/sign-in',
+    ))).toBe('https://login.example.com/sign-in');
+
+    expect(getCurrentAutofillFrameUrl(frameLocation(
+      'http:',
+      'localhost',
+      'http://localhost:3000/login',
+    ))).toBe('http://localhost:3000/login');
+  });
+
+  it('rejects inherited or opaque non-web frame URLs', () => {
+    expect(getCurrentAutofillFrameUrl(frameLocation('about:', '', 'about:blank'))).toBeNull();
+    expect(getCurrentAutofillFrameUrl(frameLocation('about:', '', 'about:srcdoc'))).toBeNull();
+    expect(getCurrentAutofillFrameUrl(frameLocation('blob:', '', 'blob:https://attacker.example/id'))).toBeNull();
+    expect(getCurrentAutofillFrameUrl(frameLocation('data:', '', 'data:text/html,<input>'))).toBeNull();
+  });
+
+  it('rejects web protocols without a hostname', () => {
+    expect(getCurrentAutofillFrameUrl(frameLocation('https:', '', 'https://'))).toBeNull();
+  });
+});

--- a/apps/browser-extension/src/entrypoints/contentScript/__tests__/WebAuthnInterceptor.test.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/__tests__/WebAuthnInterceptor.test.ts
@@ -8,7 +8,87 @@ import {
   validateWebAuthnRequest
 } from '@/utils/passkey/WebAuthnRequestValidation';
 
+import { isSameOriginWithAncestors } from '../WebAuthnInterceptor';
+
+type TestFrame = {
+  location: {
+    origin: string;
+  };
+  parent: TestFrame;
+};
+
+/**
+ * Create a minimal same-window/cross-window parent chain for ancestor checks.
+ */
+const createFrameChain = (origins: string[]): Window => {
+  const topFrame: TestFrame = {
+    location: {
+      origin: origins[origins.length - 1],
+    },
+    parent: undefined as unknown as TestFrame,
+  };
+  topFrame.parent = topFrame;
+
+  let frame = topFrame;
+  for (let index = origins.length - 2; index >= 0; index--) {
+    frame = {
+      location: {
+        origin: origins[index],
+      },
+      parent: frame,
+    };
+  }
+
+  return frame as unknown as Window;
+};
+
+/**
+ * Create a frame whose parent behaves like a browser cross-origin ancestor.
+ */
+const createFrameWithInaccessibleParent = (): Window => {
+  const inaccessibleParent: TestFrame = {
+    /**
+     * Simulate the DOMException thrown when reading a cross-origin location.
+     */
+    get location(): { origin: string } {
+      throw new Error('Permission denied');
+    },
+    parent: undefined as unknown as TestFrame,
+  };
+  inaccessibleParent.parent = inaccessibleParent;
+
+  return {
+    location: {
+      origin: 'https://login.example.com',
+    },
+    parent: inaccessibleParent,
+  } as unknown as Window;
+};
+
 describe('WebAuthnInterceptor request validation', () => {
+  it('allows WebAuthn interception in a top-level frame', () => {
+    expect(isSameOriginWithAncestors(createFrameChain(['https://login.example.com']))).toBe(true);
+  });
+
+  it('allows WebAuthn interception in same-origin nested frames', () => {
+    expect(isSameOriginWithAncestors(createFrameChain([
+      'https://login.example.com',
+      'https://login.example.com',
+      'https://login.example.com',
+    ]))).toBe(true);
+  });
+
+  it('rejects WebAuthn interception in cross-origin ancestor frames', () => {
+    expect(isSameOriginWithAncestors(createFrameChain([
+      'https://login.example.com',
+      'https://attacker.example.com',
+    ]))).toBe(false);
+  });
+
+  it('rejects WebAuthn interception when an ancestor origin cannot be read', () => {
+    expect(isSameOriginWithAncestors(createFrameWithInaccessibleParent())).toBe(false);
+  });
+
   it('allows exact RP ID matches', () => {
     expect(isRpIdAllowedForHost('example.com', 'example.com')).toBe(true);
   });


### PR DESCRIPTION
## Description
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update

Autofill and TOTP matching now only run when the current frame has an `http:` or `https:` URL with a hostname. For other frame types, the content script closes the loading popup and skips the match request before calling `GET_FILTERED_ITEMS` or `GET_ITEMS_WITH_TOTP`.

I also noticed the WebAuthn interceptor had a similar frame-boundary case, so this PR makes it fall back to native WebAuthn when the current frame has a cross-origin ancestor. That keeps browser-level iframe and permissions-policy checks in charge for those requests.

## Related Issues
- #2158

## Checklist
- [X] Code adheres to project standards and guidelines.
- [ ] Documentation has been updated where applicable.

