### PR TITLE
Copy TOTP to clipboard when authenticating with passkey too in all apps

### DIFF
--- a/apps/browser-extension/src/entrypoints/contentScript/ConditionalPasskey.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/ConditionalPasskey.ts
@@ -14,6 +14,7 @@
 import { sendMessage } from '@/utils/messaging/ExtensionMessaging';
 import type { ConditionalPasskeyOption, PasskeyGetCredentialResponse, WebAuthnPublicKeyGetPayload } from '@/utils/passkey/types';
 import type { WebAuthnGetEventDetail } from '@/utils/passkey/webauthn.types';
+import { copyTotpToClipboardIfEnabled } from '@/utils/TotpClipboard';
 
 /**
  * The response detail dispatched back to the page to settle the pending `get()` promise.
@@ -156,6 +157,14 @@ export async function completeConditionalWithPasskey(passkeyId: string): Promise
     });
 
     if (result.success && result.credential) {
+      /*
+       * Copy the linked TOTP code to the clipboard (if any).
+       */
+      const selected = request.passkeys.find((passkey) => passkey.id === passkeyId);
+      if (selected) {
+        await copyTotpToClipboardIfEnabled(selected.itemId);
+      }
+
       request.respond({ requestId: request.requestId, credential: result.credential });
       return true;
     }

--- a/apps/browser-extension/src/entrypoints/contentScript/Form.ts
+++ b/apps/browser-extension/src/entrypoints/contentScript/Form.ts
@@ -6,11 +6,11 @@ import { itemToCredential, FieldKey } from '@/utils/dist/core/models/vault';
 import { FormDetector } from '@/utils/formDetector/FormDetector';
 import { FormFiller } from '@/utils/formDetector/FormFiller';
 import { DetectedFieldType } from '@/utils/formDetector/types/FormFields';
-import { LocalPreferencesService } from '@/utils/LocalPreferencesService';
 import type { LastAutofilledCredential } from '@/utils/loginDetector';
 import { sendMessage } from '@/utils/messaging/ExtensionMessaging';
 import { ClickValidator } from '@/utils/security/ClickValidator';
 import { SqliteClient } from '@/utils/SqliteClient';
+import { copyTotpToClipboardIfEnabled } from '@/utils/TotpClipboard';
 
 /**
  * Global timestamp to track popup debounce time.
@@ -146,25 +146,7 @@ export async function fillItem(item: Item, input: HTMLInputElement): Promise<voi
   });
 
   // Auto-copy TOTP to clipboard if enabled and item has TOTP after autofill.
-  const autoCopyTotpEnabled = await LocalPreferencesService.getAutoCopyTotpOnAutofill();
-  if (autoCopyTotpEnabled) {
-    try {
-      // Generate TOTP code via background
-      const response = await sendMessage('GENERATE_TOTP_CODE', { itemId: item.Id });
-
-      if (response.success && response.code) {
-        // Copy TOTP code to clipboard
-        await navigator.clipboard.writeText(response.code);
-
-        // Notify background script that clipboard was copied to start countdown
-        sendMessage('CLIPBOARD_COPIED').catch(() => {
-          // Ignore errors as background script might not be ready
-        });
-      }
-    } catch {
-      // Silently fail in case TOTP code is not available which is possible.
-    }
-  }
+  await copyTotpToClipboardIfEnabled(item.Id);
 }
 
 /**

--- a/apps/browser-extension/src/entrypoints/popup/pages/passkeys/PasskeyAuthenticate.tsx
+++ b/apps/browser-extension/src/entrypoints/popup/pages/passkeys/PasskeyAuthenticate.tsx
@@ -15,6 +15,7 @@ import { buildPasskeyAssertion } from '@/utils/passkey/PasskeyAssertionService';
 import { PasskeyHelper } from '@/utils/passkey/PasskeyHelper';
 import type { PendingPasskeyGetRequest } from '@/utils/passkey/types';
 import { extractDomain } from '@/utils/RustCore';
+import { copyTotpToClipboardIfEnabled } from '@/utils/TotpClipboard';
 
 /**
  * PasskeyAuthenticate
@@ -27,7 +28,7 @@ const PasskeyAuthenticate: React.FC = () => {
   const [request, setRequest] = useState<PendingPasskeyGetRequest | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availablePasskeys, setAvailablePasskeys] = useState<Array<{ id: string; displayName: string; rpId: string; serviceName?: string | null }>>([]);
+  const [availablePasskeys, setAvailablePasskeys] = useState<Array<{ id: string; itemId: string; displayName: string; rpId: string; serviceName?: string | null }>>([]);
   const [showBypassDialog, setShowBypassDialog] = useState(false);
   const { isLocked } = useVaultLockRedirect();
   const firstPasskeyRef = useRef<HTMLDivElement>(null);
@@ -81,8 +82,9 @@ const PasskeyAuthenticate: React.FC = () => {
             }
 
             // Map to display format
-            setAvailablePasskeys(filteredPasskeys.map((pk: { Id: string; DisplayName: string; ServiceName?: string | null; RpId: string; Username?: string | null }) => ({
+            setAvailablePasskeys(filteredPasskeys.map((pk: { Id: string; ItemId: string; DisplayName: string; ServiceName?: string | null; RpId: string; Username?: string | null }) => ({
               id: pk.Id,
+              itemId: pk.ItemId,
               displayName: pk.DisplayName,
               serviceName: pk.ServiceName,
               rpId: pk.RpId,
@@ -146,6 +148,14 @@ const PasskeyAuthenticate: React.FC = () => {
     try {
       // Build the assertion from the selected passkey using the shared service.
       const credential = await buildPasskeyAssertion(dbContext.sqliteClient, request, passkeyId);
+
+      /*
+       * Copy the linked TOTP code to the clipboard (if any).
+       */
+      const selected = availablePasskeys.find((pk) => pk.id === passkeyId);
+      if (selected) {
+        await copyTotpToClipboardIfEnabled(selected.itemId);
+      }
 
       /*
        * Send response back

--- a/apps/browser-extension/src/utils/TotpClipboard.ts
+++ b/apps/browser-extension/src/utils/TotpClipboard.ts
@@ -1,0 +1,32 @@
+import { LocalPreferencesService } from '@/utils/LocalPreferencesService';
+import { sendMessage } from '@/utils/messaging/ExtensionMessaging';
+
+/**
+ * Copy an item's current TOTP code to the clipboard (only when the user has the copy-on-fill
+ * setting enabled, which is the default).
+ *
+ * @param itemId - The ID of the item being filled.
+ */
+export async function copyTotpToClipboardIfEnabled(itemId: string): Promise<void> {
+  try {
+    if (!await LocalPreferencesService.getAutoCopyTotpOnAutofill()) {
+      return;
+    }
+
+    // Generate TOTP code via background
+    const response = await sendMessage('GENERATE_TOTP_CODE', { itemId });
+
+    if (!response.success || !response.code) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(response.code);
+
+    // Notify background script that clipboard was copied to start countdown
+    sendMessage('CLIPBOARD_COPIED').catch(() => {
+      // Ignore errors as background script might not be ready
+    });
+  } catch {
+    // Silently fail if the TOTP code is not available.
+  }
+}

--- a/apps/browser-extension/tests/e2e/09-save-login-prompt.spec.ts
+++ b/apps/browser-extension/tests/e2e/09-save-login-prompt.spec.ts
@@ -135,6 +135,41 @@ async function fillServiceName(page: Page, serviceName: string): Promise<void> {
 }
 
 /**
+ * Helper to check if the autofill credential popup is open.
+ * Requires E2E test mode (open shadow DOM); reports false when the shadow root is closed.
+ */
+async function isAutofillPopupOpen(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const ui = document.querySelector('aliasvault-ui');
+    return ui?.shadowRoot?.querySelector('#aliasvault-credential-popup') != null;
+  });
+}
+
+/**
+ * Helper to dismiss the autofill credential popup, which is anchored under the password field and
+ * covers the submit button while it is open.
+ *
+ * Focusing an input opens the popup asynchronously, so a single outside click can land before the
+ * popup exists: its outside-click handler then finds nothing to close and the popup shows up right
+ * afterwards. Click outside until it is gone and stays gone.
+ */
+async function dismissAutofillPopup(page: Page, timeout: number = 10000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    // Click on the form title, which sits safely above the input fields.
+    await page.click('h1');
+
+    // Give any in-flight popup open time to land before concluding it is dismissed.
+    await page.waitForTimeout(300);
+    if (!await isAutofillPopupOpen(page)) {
+      return;
+    }
+  }
+
+  throw new Error(`Autofill popup stayed open after ${timeout}ms and would block the submit button`);
+}
+
+/**
  * Helper to submit the login form on the test page.
  * Waits for the content script to initialize before filling and submitting.
  */
@@ -145,10 +180,8 @@ async function submitLoginForm(page: Page, username: string, password: string): 
   await page.fill('input#username', username);
   await page.fill('input#password', password);
 
-  // Click outside the form fields to dismiss any autofill popup that might be blocking the submit button
-  // We click on the form title which is safely above the input fields
-  await page.click('h1');
-  await page.waitForTimeout(200);
+  // Dismiss the autofill popup so it cannot swallow the click meant for the submit button.
+  await dismissAutofillPopup(page);
 
   // Click the submit button - this triggers the LoginDetector's button click handler
   await page.click('button[type="submit"]');

--- a/apps/browser-extension/tests/fixtures/TestClient.ts
+++ b/apps/browser-extension/tests/fixtures/TestClient.ts
@@ -25,6 +25,7 @@ import {
   waitForUnlockPage,
   waitForOfflineIndicator,
   waitForLoginForm,
+  waitForPopupReady,
   Timeouts,
 } from './waits';
 
@@ -70,10 +71,7 @@ export class TestClient {
     // Open popup
     const popup = await context.newPage();
     await popup.goto(`chrome-extension://${extensionId}/popup.html`);
-    await popup.waitForSelector('input[type="text"], input[type="password"], button#settings', {
-      state: 'visible',
-      timeout: Timeouts.MEDIUM,
-    });
+    await waitForPopupReady(popup, Timeouts.MEDIUM);
 
     return new TestClient(context, extensionId, popup);
   }
@@ -84,10 +82,7 @@ export class TestClient {
   static async fromContext(context: BrowserContext, extensionId: string): Promise<TestClient> {
     const popup = await context.newPage();
     await popup.goto(`chrome-extension://${extensionId}/popup.html`);
-    await popup.waitForSelector('input[type="text"], input[type="password"], button#settings', {
-      state: 'visible',
-      timeout: Timeouts.MEDIUM,
-    });
+    await waitForPopupReady(popup, Timeouts.MEDIUM);
     return new TestClient(context, extensionId, popup);
   }
 
@@ -96,8 +91,11 @@ export class TestClient {
    * Verifies the URL is displayed on the login page after configuration.
    */
   async configureApiUrl(apiUrl: string): Promise<this> {
-    const settingsButton = await this.popup.waitForSelector('button#settings');
-    await settingsButton.click();
+    // Make sure the popup has settled on the login page before touching the header.
+    await waitForPopupReady(this.popup);
+
+    // Use a locator so the button is re-resolved if the app re-renders mid-click.
+    await this.popup.locator('button#settings').click();
     await this.popup.selectOption('select', ['custom']);
     await this.popup.fill('input#custom-api-url', apiUrl);
     await this.popup.click('button#back');
@@ -118,6 +116,7 @@ export class TestClient {
    * Open the login settings page (before authentication).
    */
   async openLoginSettings(): Promise<this> {
+    await waitForPopupReady(this.popup);
     const settingsButton = this.popup.locator('button#settings');
     await settingsButton.click();
     await expect(this.popup.locator('select')).toBeVisible();

--- a/apps/browser-extension/tests/fixtures/fixtures.ts
+++ b/apps/browser-extension/tests/fixtures/fixtures.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url';
 
 import { createTestUser, type TestUser } from '../helpers/test-api';
 
+import { waitForPopupReady as waitForPopupReadyState, Timeouts } from './waits';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -126,20 +128,13 @@ export async function closeCachedContext(): Promise<void> {
  * Helper to wait for the popup to finish initial loading.
  *
  * The popup shows a loading spinner overlay (with z-50) during initial load.
- * This function waits for actual content to be visible, indicating loading is complete.
+ * This function waits for that overlay to disappear and for actual content to be visible.
  *
  * @param popup - The popup page
  * @param timeout - Maximum time to wait in milliseconds (default: 10000)
  */
-export async function waitForPopupReady(popup: Page, timeout: number = 10000): Promise<void> {
-  // Wait for the loading overlay to disappear by waiting for actual content to be interactable.
-  // The login form has input fields that only become visible after loading completes.
-  // We wait for either the login form inputs OR the settings button (visible on login page).
-  // Using CSS-only selectors to avoid mixing with Playwright-specific selectors.
-  await popup.waitForSelector(
-    'input[type="text"], input[type="password"], button#settings',
-    { state: 'visible', timeout }
-  );
+export async function waitForPopupReady(popup: Page, timeout: number = Timeouts.MEDIUM): Promise<void> {
+  await waitForPopupReadyState(popup, timeout);
 }
 
 /**
@@ -184,9 +179,11 @@ export async function waitForLoggedIn(popup: Page, timeout: number = 30000): Pro
  * @param apiUrl - The API URL to configure
  */
 export async function configureApiUrl(popup: Page, apiUrl: string): Promise<void> {
-  // Click settings button
-  const settingsButton = await popup.waitForSelector('button#settings');
-  await settingsButton.click();
+  // Make sure the popup has settled on the login page before touching the header.
+  await waitForPopupReady(popup);
+
+  // Click settings button. Use a locator so it is re-resolved if the app re-renders mid-click.
+  await popup.locator('button#settings').click();
 
   // Select "Self-hosted" (custom) option
   await popup.selectOption('select', ['custom']);

--- a/apps/browser-extension/tests/fixtures/waits.ts
+++ b/apps/browser-extension/tests/fixtures/waits.ts
@@ -4,9 +4,8 @@
  * This module provides condition-based waiting functions that replace
  * fixed timeouts with intelligent waits for specific UI states.
  */
-import type { Page, Locator } from '@playwright/test';
+import { expect, type Page, type Locator } from '@playwright/test';
 
-import { expect } from './fixtures';
 import { FieldSelectors } from './selectors';
 
 /**
@@ -17,6 +16,12 @@ export const Timeouts = {
   MEDIUM: 10000,
   LONG: 30000,
 } as const;
+
+/**
+ * Full-screen overlays the popup renders while it is busy: the initial load overlay in App.tsx
+ * and the shared LoadingSpinnerFullScreen. Both cover the whole popup and swallow clicks.
+ */
+const LOADING_OVERLAY = 'div.fixed.inset-0.z-50';
 
 /**
  * Generic wait helper that waits for a locator to be visible.
@@ -37,6 +42,35 @@ export async function waitFor(locator: Locator, timeout: number = Timeouts.MEDIU
  */
 export async function waitForHidden(locator: Locator, timeout: number = Timeouts.MEDIUM): Promise<void> {
   await locator.waitFor({ state: 'hidden', timeout });
+}
+
+/**
+ * Wait for the full-screen loading overlay to disappear.
+ *
+ * @param popup - The popup page
+ * @param timeout - Timeout in milliseconds
+ */
+export async function waitForLoadingOverlayGone(popup: Page, timeout: number = Timeouts.MEDIUM): Promise<void> {
+  await popup.locator(LOADING_OVERLAY).first().waitFor({ state: 'detached', timeout });
+}
+
+/**
+ * Wait for the popup to finish its initial load and settle on its destination page.
+ *
+ * The popup boots on `/`, hops through `/reinitialize` and only then lands on `/login`, `/unlock`
+ * or the vault. The loading overlay stays up across that whole hop, so waiting only for content to
+ * be visible returns while the app is still routing: the click then lands on the overlay, and the
+ * layout swap that follows replaces the header, detaching anything the test grabbed beforehand.
+ * Waiting for the overlay first guarantees the destination page is mounted before we touch it.
+ *
+ * @param popup - The popup page
+ * @param timeout - Timeout in milliseconds
+ */
+export async function waitForPopupReady(popup: Page, timeout: number = Timeouts.MEDIUM): Promise<void> {
+  await waitForLoadingOverlayGone(popup, timeout);
+
+  // Auth form inputs (login/unlock) or the settings button (login page header) indicate content is interactable.
+  await popup.locator('input[type="text"], input[type="password"], button#settings').first().waitFor({ state: 'visible', timeout });
 }
 
 /**

--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillFillActivity.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillFillActivity.kt
@@ -1,14 +1,9 @@
 package net.aliasvault.app.autofill
 
 import android.app.Activity
-import android.content.ClipData
-import android.content.ClipDescription
-import android.content.ClipboardManager
-import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.service.autofill.Dataset
 import android.util.Log
 import android.view.autofill.AutofillId
@@ -17,7 +12,7 @@ import android.widget.RemoteViews
 import net.aliasvault.app.R
 import net.aliasvault.app.autofill.models.FieldType
 import net.aliasvault.app.autofill.utils.AutofillFieldMapper
-import net.aliasvault.app.utils.TotpGenerator
+import net.aliasvault.app.utils.TotpClipboard
 import net.aliasvault.app.vaultstore.VaultStore
 
 /**
@@ -80,7 +75,7 @@ class AutofillFillActivity : Activity() {
             }
 
             if (copyTotp) {
-                tryCopyTotpToClipboard(store, itemId)
+                TotpClipboard.copyCodeForItem(this, store, itemId)
             }
 
             val fields = pairFields(autofillIds, fieldTypeOrdinals)
@@ -120,27 +115,6 @@ class AutofillFillActivity : Activity() {
         val types = FieldType.values()
         return autofillIds.mapIndexed { i, id ->
             id to (types.getOrNull(fieldTypeOrdinals[i]) ?: FieldType.UNKNOWN)
-        }
-    }
-
-    private fun tryCopyTotpToClipboard(store: VaultStore, itemId: String) {
-        val secret = store.getTotpSecretForItem(itemId) ?: return
-        val code = TotpGenerator.generateCode(secret) ?: return
-        if (code.isEmpty()) return
-
-        try {
-            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("AliasVault", code)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                val extras = PersistableBundle().apply {
-                    putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
-                }
-                clip.description.extras = extras
-            }
-            clipboard.setPrimaryClip(clip)
-            Log.d(TAG, "TOTP code copied to clipboard during autofill")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to copy TOTP code to clipboard", e)
         }
     }
 }

--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillService.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillService.kt
@@ -30,6 +30,7 @@ import net.aliasvault.app.autofill.utils.AutofillDatasetBuilder
 import net.aliasvault.app.autofill.utils.FieldFinder
 import net.aliasvault.app.autofill.utils.InlinePresentationHelper
 import net.aliasvault.app.autofill.utils.RustItemMatcher
+import net.aliasvault.app.utils.TotpClipboard
 import net.aliasvault.app.vaultstore.VaultStore
 import net.aliasvault.app.vaultstore.interfaces.ItemOperationCallback
 import net.aliasvault.app.vaultstore.models.Item
@@ -181,7 +182,7 @@ class AutofillService : AutofillService() {
                             // Add debug dataset if enabled in settings
                             val sharedPreferences = getSharedPreferences("AliasVaultPrefs", android.content.Context.MODE_PRIVATE)
                             val showSearchText = sharedPreferences.getBoolean("autofill_show_search_text", false)
-                            val copyTotpOnFill = sharedPreferences.getBoolean("autofill_copy_totp_on_fill", true)
+                            val copyTotpOnFill = TotpClipboard.isCopyOnFillEnabled(this@AutofillService)
                             if (showSearchText) {
                                 responseBuilder.addDataset(createSearchDebugDataset(fieldFinder, appInfo ?: "unknown", inlinePool))
                             }

--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillUnlockActivity.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/autofill/AutofillUnlockActivity.kt
@@ -19,6 +19,7 @@ import net.aliasvault.app.autofill.utils.AutofillDatasetBuilder
 import net.aliasvault.app.autofill.utils.RustItemMatcher
 import net.aliasvault.app.credentialprovider.UnlockCoordinator
 import net.aliasvault.app.utils.ErrorScreenView
+import net.aliasvault.app.utils.TotpClipboard
 import net.aliasvault.app.vaultstore.VaultStore
 import net.aliasvault.app.vaultstore.keystoreprovider.AndroidKeystoreProvider
 import net.aliasvault.app.vaultstore.storageprovider.AndroidStorageProvider
@@ -149,8 +150,7 @@ class AutofillUnlockActivity : FragmentActivity() {
             "Post-unlock items: app matches=${filteredByApp.size}, with data=${matchingItems.size}",
         )
 
-        val copyTotpOnFill = getSharedPreferences("AliasVaultPrefs", MODE_PRIVATE)
-            .getBoolean("autofill_copy_totp_on_fill", true)
+        val copyTotpOnFill = TotpClipboard.isCopyOnFillEnabled(this)
 
         val responseBuilder = FillResponse.Builder()
         if (matchingItems.isEmpty()) {

--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/credentialprovider/PasskeyAuthenticationActivity.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/credentialprovider/PasskeyAuthenticationActivity.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withContext
 import net.aliasvault.app.R
 import net.aliasvault.app.utils.ErrorScreenView
 import net.aliasvault.app.utils.Helpers
+import net.aliasvault.app.utils.TotpClipboard
 import net.aliasvault.app.vaultstore.VaultStore
 import net.aliasvault.app.vaultstore.keystoreprovider.AndroidKeystoreProvider
 import net.aliasvault.app.vaultstore.passkey.PasskeyAuthenticator
@@ -260,6 +261,16 @@ class PasskeyAuthenticationActivity : FragmentActivity() {
                     assertion = assertion,
                     clientDataJson = clientDataJson,
                 )
+
+                // If the item behind this passkey also has a TOTP code and the user has the
+                // copy-on-fill setting enabled (default), write the current code to the clipboard.
+                if (TotpClipboard.isCopyOnFillEnabled(this@PasskeyAuthenticationActivity)) {
+                    TotpClipboard.copyCodeForItem(
+                        context = this@PasskeyAuthenticationActivity,
+                        store = vaultStore,
+                        itemId = passkey.parentItemId.toString(),
+                    )
+                }
 
                 val resultIntent = Intent()
                 try {

--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/utils/TotpClipboard.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/utils/TotpClipboard.kt
@@ -1,0 +1,61 @@
+package net.aliasvault.app.utils
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.PersistableBundle
+import android.util.Log
+import net.aliasvault.app.vaultstore.VaultStore
+
+/**
+ * Puts an item's current TOTP code on the clipboard while autofilling, so the user can paste it
+ * into the 2FA field after the fill completes.
+ */
+object TotpClipboard {
+    private const val TAG = "TotpClipboard"
+
+    /** Shared preferences file holding the app's autofill settings. */
+    private const val PREFS_NAME = "AliasVaultPrefs"
+
+    /** Preference key for the copy-TOTP-on-fill setting. */
+    private const val PREF_COPY_TOTP_ON_FILL = "autofill_copy_totp_on_fill"
+
+    /**
+     * Whether the user wants the item's TOTP code copied to the clipboard on autofill.
+     * Defaults to true when the setting has never been written.
+     */
+    fun isCopyOnFillEnabled(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(PREF_COPY_TOTP_ON_FILL, true)
+    }
+
+    /**
+     * Copy the current TOTP code of the passed item to the clipboard.
+     *
+     * @param context The context used for the clipboard service.
+     * @param store The unlocked vault store to read the TOTP secret from.
+     * @param itemId The ID of the item being filled.
+     */
+    fun copyCodeForItem(context: Context, store: VaultStore, itemId: String) {
+        val secret = store.getTotpSecretForItem(itemId) ?: return
+        val code = TotpGenerator.generateCode(secret) ?: return
+        if (code.isEmpty()) return
+
+        try {
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clip = ClipData.newPlainText("AliasVault", code)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val extras = PersistableBundle().apply {
+                    putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+                }
+                clip.description.extras = extras
+            }
+            clipboard.setPrimaryClip(clip)
+            Log.d(TAG, "TOTP code copied to clipboard during autofill")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to copy TOTP code to clipboard", e)
+        }
+    }
+}

--- a/apps/mobile-app/ios/Autofill/CredentialProviderViewController+Credential.swift
+++ b/apps/mobile-app/ios/Autofill/CredentialProviderViewController+Credential.swift
@@ -128,13 +128,7 @@ extension CredentialProviderViewController: CredentialProviderDelegate {
                 // copy-on-fill setting enabled (default), put the current
                 // TOTP code on the clipboard so they can paste it into the
                 // 2FA field after the autofill completes.
-                if matchingCredential.hasTotp,
-                   let secret = matchingCredential.totpSecret,
-                   AutofillSettings.shouldCopyTotpOnFill,
-                   let code = TotpGenerator.generateCode(secret: secret),
-                   !code.isEmpty {
-                    UIPasteboard.general.string = code
-                }
+                TotpClipboard.copyCodeIfEnabled(secret: matchingCredential.totpSecret)
 
                 // Use the identifier that matches the credential identity
                 let identifier = request.credentialIdentity.user

--- a/apps/mobile-app/ios/Autofill/CredentialProviderViewController+Passkey.swift
+++ b/apps/mobile-app/ios/Autofill/CredentialProviderViewController+Passkey.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import VaultStoreKit
 import VaultUI
 import VaultModels
+import VaultUtils
 import CryptoKit
 
 /**
@@ -83,6 +84,11 @@ extension CredentialProviderViewController: PasskeyProviderDelegate {
                 prfInputs: prfInputs,
                 prfSecret: passkey.prfKey
             )
+
+            // If the item behind this passkey also has a TOTP code and the user has the
+            // copy-on-fill setting enabled (default), put the current code on the clipboard.
+            let totpSecret = (try? vaultStore.getFirstTotpCode(forItemId: passkey.parentItemId))??.secretKey
+            TotpClipboard.copyCodeIfEnabled(secret: totpSecret)
 
             // Build extension output if PRF results are available (iOS 18+)
             if #available(iOS 18.0, *), let prfResults = assertion.prfResults {
@@ -652,6 +658,10 @@ extension CredentialProviderViewController: PasskeyProviderDelegate {
                 ))
                 return
             }
+
+            // If the credential also has a TOTP code and the user has the copy-on-fill setting
+            // enabled (default), put the current code on the clipboard.
+            TotpClipboard.copyCodeIfEnabled(secret: credential.totpSecret)
 
             // Extract PRF inputs from the passkey request if available
             var prfInputs: PrfInputs?

--- a/apps/mobile-app/ios/Podfile.lock
+++ b/apps/mobile-app/ios/Podfile.lock
@@ -2768,7 +2768,7 @@ SPEC CHECKSUMS:
   ExpoUI: b8da9e23eb4cef30e4797bc6de102a9178e6cd2b
   ExpoWebBrowser: 6e3d90e3fe1952d21a8494872b1e1a485cd50e2f
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: a384bd37273f335daf0965c0fd0aa46f197e0175
+  hermes-engine: f684a01742a30bb5d7332da47aa184074d8ae9b4
   Macaw: 7af8ea57aa2cab35b4a52a45e6f85eea753ea9ae
   OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
@@ -2779,7 +2779,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: b87f4cdecb2229f7d0943644cef9a084d433983d
+  React-Core-prebuilt: 43e26cf5ff020a09ab026c6f6277ad013fa0044f
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -2849,7 +2849,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 8538eb1bd61031ede1dadd7d725ee1d42dbdceaa
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: b8c3edb93459c2b4531665273e0e904ab3c12ba2
+  ReactNativeDependencies: 2c0483134df7ac059c1f1c484b4fbf6a40451fb5
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
   RNReanimated: f735b1747a7a93bda7ca102c6d37a3cf54b6d5e8

--- a/apps/mobile-app/ios/VaultUI/Selection/CredentialProviderView.swift
+++ b/apps/mobile-app/ios/VaultUI/Selection/CredentialProviderView.swift
@@ -261,13 +261,7 @@ private struct AutofillCredentialCardWithSelection: View {
                 // copy-on-fill setting enabled (default), put the current
                 // TOTP code on the clipboard so they can paste it into the
                 // 2FA field after the autofill completes.
-                if credential.hasTotp,
-                   let secret = credential.totpSecret,
-                   AutofillSettings.shouldCopyTotpOnFill,
-                   let code = TotpGenerator.generateCode(secret: secret),
-                   !code.isEmpty {
-                    UIPasteboard.general.string = code
-                }
+                TotpClipboard.copyCodeIfEnabled(secret: credential.totpSecret)
 
                 // Fill both username and password immediately for normal autofill
                 onSelect(identifier, credential.password ?? "")

--- a/apps/mobile-app/ios/VaultUtils/TotpClipboard.swift
+++ b/apps/mobile-app/ios/VaultUtils/TotpClipboard.swift
@@ -1,0 +1,19 @@
+import Foundation
+import UIKit
+
+/// Puts a credential's current TOTP code on the clipboard while autofilling, so the user can
+/// paste it into the 2FA field after the fill completes.
+public enum TotpClipboard {
+    /// Copy the current TOTP code for `secret` to the clipboard (only when the user has the
+    /// copy-on-fill setting enabled, which is the default).
+    public static func copyCodeIfEnabled(secret: String?) {
+        guard AutofillSettings.shouldCopyTotpOnFill,
+              let secret = secret, !secret.isEmpty,
+              let code = TotpGenerator.generateCode(secret: secret),
+              !code.isEmpty else {
+            return
+        }
+
+        UIPasteboard.general.string = code
+    }
+}


### PR DESCRIPTION
## Description
Currently the TOTP code (if any) was only copied when logging in via username/password autofill. This PR adds the same logic to passkey authentication flow as well, as some websites can still require a 2FA entry even when authenticating with a passkey.
- [x] Bug fix

## Related Issues
- #2305

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.

